### PR TITLE
Use a `.gitattributes` file to prevent exporting images/GIFs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/ export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to prevent shipping any of the images or GIF's to end users. These are just used for demonstration purposes and serve no purpose for the user that use the package.