### PR TITLE
fix: tags able to have inner parenthesis

### DIFF
--- a/edge.sublime-syntax
+++ b/edge.sublime-syntax
@@ -51,7 +51,7 @@ contexts:
         0: comment.block
       pop: true
     - meta_scope: comment.block
-  
+
   # End of comment block
   comment:
     - match: "(--}})"
@@ -62,12 +62,12 @@ contexts:
 
   # Process tag contents as Javascript
   tag:
-    - match: \)
+    - match: \)\n
       pop: true
     - match: ""
       push: "Packages/JavaScript/JavaScript.sublime-syntax"
       with_prototype:
-        - match: (?=\))
+        - match: (?=\)\n)
           pop: true
 
   # Process safe mustache contents as Javascript


### PR DESCRIPTION
- don't pop out of context on the first instance of closing parenthesis
- pop out of context only if closing parenthesis is followed by a new line
  - `A tag must always appear in its line and cannot be mixed with other contents.`

### 🔗 Linked issue

#4 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Have the closing parenthesis be followed with a new line before popping out of context since [edge tags must be on its own line](https://docs.adonisjs.com/guides/views/templating-syntax#edge-tags).

Before:
![edge-syntax-before](https://github.com/edge-js/edge-sublime/assets/10394949/80522c9f-4ba0-4b38-ba34-c738fc40c27c)

After:
![edge-syntax-after](https://github.com/edge-js/edge-sublime/assets/10394949/0fd32ea7-2852-44db-a0ff-c2d7d638cee0)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
